### PR TITLE
Initial gist-BFO mapping

### DIFF
--- a/gist_bfo_bridge.ttl
+++ b/gist_bfo_bridge.ttl
@@ -1,0 +1,174 @@
+# imports: http://purl.obolibrary.org/obo/bfo/2.0/bfo.owl
+# imports: https://w3id.org/semanticarts/ontology/gistCore13.0.0
+
+@prefix gist: <https://w3id.org/semanticarts/ns/ontology/gist/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://ontologies.semanticarts.com/gistBFO>
+	a owl:Ontology ;
+	owl:imports
+		<http://purl.obolibrary.org/obo/bfo/2020/bfo-core.ttl> ,
+		<https://w3id.org/semanticarts/ontology/gistCore13.0.0>
+		;
+	owl:versionIRI <https://ontologies.semanticarts.com/gistBFO.0.1.0> ;
+	.
+
+skos:editorialNote
+	a owl:AnnotationProperty ;
+	.
+
+gist:Aspect
+	rdfs:subClassOf obo:BFO_0000034 ;
+	skos:editorialNote "BFO Alignment: Function in BFO covers a lot of ground, but it could cover our aspects which are specific to measurements."^^xsd:string ;
+	.
+
+gist:Building
+	rdfs:subClassOf obo:BFO_0000030 ;
+	skos:editorialNote "BFO Alignment: Building is clearly a material entity. Initial mapping will map to the 'object' subclass."^^xsd:string ;
+	.
+
+gist:Category
+	rdfs:subClassOf obo:BFO_0000020 ;
+	skos:editorialNote "BFO Alignment: BFO does not seem to have categories, maybe because everything in BFO is a category."^^xsd:string ;
+	.
+
+gist:Collection
+	rdfs:subClassOf obo:BFO_0000002 ;
+	skos:editorialNote "BFO Alignment: Because gist collections could be anything and BFO 'object aggregate' is for physical items, collection maps to a superclass."^^xsd:string ;
+	.
+
+gist:Commitment
+	rdfs:subClassOf obo:BFO_0000003 ;
+	skos:editorialNote "BFO Alignment: Commitments occur in time because there is a point at which a thing becomes a commitment and a duration over which a party acts to meet the commitment."^^xsd:string ;
+	.
+
+gist:Component
+	rdfs:subClassOf obo:BFO_0000030 ;
+	.
+
+gist:Content
+	rdfs:subClassOf obo:BFO_0000031 ;
+	skos:editorialNote "BFO Alignment: Content seems to be a proper subset of generically dependent continuant."^^xsd:string ;
+	.
+
+gist:Equipment
+	rdfs:subClassOf obo:BFO_0000030 ;
+	skos:editorialNote "BFO Alignment: Equipment is clearly a material entity. Initial mapping will map to the 'object' subclass."^^xsd:string ;
+	.
+
+gist:Event
+	rdfs:subClassOf obo:BFO_0000003 ;
+	.
+
+gist:GeoPoint
+	rdfs:subClassOf obo:BFO_0000018 ;
+	.
+
+gist:GeoRegion
+	rdfs:subClassOf obo:BFO_0000009 ;
+	.
+
+gist:GeoRoute
+	rdfs:subClassOf obo:BFO_0000006 ;
+	skos:editorialNote "BFO Alignment: Routes are collections of one dimensional regions, but they may trace out a 2D path."^^xsd:string ;
+	.
+
+gist:GeoSegment
+	rdfs:subClassOf obo:BFO_0000026 ;
+	.
+
+gist:GeoVolume
+	rdfs:subClassOf obo:BFO_0000028 ;
+	.
+
+gist:IntellectualProperty
+	rdfs:subClassOf [
+		owl:unionOf (
+			obo:BFO_0000141
+			obo:BFO_0000031
+		)
+	] ;
+	skos:editorialNote "Intellectual property includes both immaterial knowledge and physically represented knowledge."^^xsd:string ;
+	.
+
+gist:Intention
+	rdfs:subClassOf obo:BFO_0000003 ;
+	.
+
+gist:Language
+	rdfs:subClassOf obo:BFO_0000031 ;
+	skos:editorialNote "BFO Alignment: Language fits the pattern of being continuant because it persists through change, but doesn't have an independent nature."^^xsd:string ;
+	.
+
+gist:Magnitude
+	rdfs:subClassOf obo:BFO_0000019 ;
+	.
+
+gist:Network
+	rdfs:subClassOf obo:BFO_0000027 ;
+	.
+
+gist:NetworkLink
+	rdfs:subClassOf obo:BFO_0000024 ;
+	skos:editorialNote "BFO Alignment: Fiat object part is a pretty good cover for network link."^^xsd:string ;
+	.
+
+gist:NetworkNode
+	rdfs:subClassOf obo:BFO_0000024 ;
+	skos:editorialNote "BFO Alignment: Network node also fits the fiat object part as the node could be virtual or instantiated."^^xsd:string ;
+	.
+
+gist:OrderedMember
+	rdfs:subClassOf obo:BFO_0000023 ;
+	skos:editorialNote "BFO Alignment: The ordered member defines the role the proxied real world item plays in the ordered collection."^^xsd:string ;
+	.
+
+gist:Organization
+	rdfs:subClassOf obo:BFO_0000141 ;
+	skos:editorialNote "BFO Alignment: Organization is clearly an independent continuant and immaterial. May need to update to be consistent with Common Core Ontology as well."^^xsd:string ;
+	.
+
+gist:PhysicalIdentifiableItem
+	rdfs:subClassOf obo:BFO_0000004, [ owl:complementOf obo:BFO_0000006 ]   ;
+	.
+
+gist:PhysicalSubstance
+	rdfs:subClassOf
+		obo:BFO_0000040 ,
+		[ owl:complementOf obo:BFO_0000030 ] ,
+		[ owl:complementOf obo:BFO_0000027 ]
+		;
+	skos:editorialNote "BFO Alignment: Physical substance is a material entity, but not an object or aggregate as those are physical identifiable items and collections."^^xsd:string ;
+	.
+
+gist:SchemaMetaData
+	rdfs:subClassOf obo:BFO_0000031 ;
+	.
+
+gist:System
+	rdfs:subClassOf obo:BFO_0000027 ;
+	.
+
+gist:Template
+	rdfs:subClassOf obo:BFO_0000031 ;
+	.
+
+gist:TemporalRelation
+	rdfs:subClassOf obo:BFO_0000145 ;
+	skos:editorialNote "BFO Alignment: Other potential matches include role and occurrent."^^xsd:string ;
+	.
+
+gist:TimeInterval
+	rdfs:subClassOf obo:BFO_0000038 ;
+	.
+
+gist:UnitOfMeasure
+	skos:editorialNote "BFO Alignment: Unclear if unit of measure fits in BFO. To avoid potentially inconsistent ontologies, it is initially not mapped to BFO."^^xsd:string ;
+	.
+


### PR DESCRIPTION
This ontology maps gist to BFO by creating subclass relationships between gist and BFO. gist classes should be subclasses of their most specific BFO superclass. OBO curator notes are used to track our reasoning for aligning particular classes and may contain other considerations used to make a determination. They should contain more information than simply the label of the aligned BFO class.