### PR TITLE
Create annotation for mapping notes

### DIFF
--- a/gist_bfo_bridge.ttl
+++ b/gist_bfo_bridge.ttl
@@ -23,28 +23,35 @@ skos:editorialNote
 	a owl:AnnotationProperty ;
 	.
 
+gist:bfoMappingNote
+	a owl:AnnotationProperty ;
+	rdfs:subPropertyOf skos:editorialNote ;
+	skos:definition "Information regarding the mapping between gist and BFO ontologies, how a resource was mapped, or clarifcations on the mapping."^^xsd:string ;
+	skos:prefLabel "BFO mapping note"^^xsd:string ;
+	.
+
 gist:Agreement
 	rdfs:subClassOf obo:BFO_0000145 ;
 	.
 
 gist:Aspect
 	rdfs:subClassOf obo:BFO_0000034 ;
-	skos:editorialNote "BFO Alignment: Function in BFO covers a lot of ground, but it could cover our aspects which are specific to measurements."^^xsd:string ;
+	gist:bfoMappingNote "Function in BFO covers a lot of ground, but it could cover our aspects which are specific to measurements."^^xsd:string ;
 	.
 
 gist:Building
 	rdfs:subClassOf obo:BFO_0000030 ;
-	skos:editorialNote "BFO Alignment: Building is clearly a material entity. Initial mapping will map to the 'object' subclass."^^xsd:string ;
+	gist:bfoMappingNote "Building is clearly a material entity. Initial mapping will map to the objects subclass."^^xsd:string ;
 	.
 
 gist:Category
 	rdfs:subClassOf obo:BFO_0000020 ;
-	skos:editorialNote "BFO Alignment: BFO does not seem to have categories, maybe because everything in BFO is a category."^^xsd:string ;
+	gist:bfoMappingNote "BFO does not seem to have categories, maybe because everything in BFO is a category."^^xsd:string ;
 	.
 
 gist:Collection
 	rdfs:subClassOf obo:BFO_0000002 ;
-	skos:editorialNote "BFO Alignment: Because gist collections could be anything and BFO 'object aggregate' is for physical items, collection maps to a superclass."^^xsd:string ;
+	gist:bfoMappingNote "Because gist collections could be anything and BFO 'object aggregate' is for physical items, collection maps to a superclass."^^xsd:string ;
 	.
 
 gist:Commitment
@@ -57,12 +64,12 @@ gist:Component
 
 gist:Content
 	rdfs:subClassOf obo:BFO_0000031 ;
-	skos:editorialNote "BFO Alignment: Content seems to be a proper subset of generically dependent continuant."^^xsd:string ;
+	gist:bfoMappingNote "Content seems to be a proper subset of generically dependent continuant."^^xsd:string ;
 	.
 
 gist:Equipment
 	rdfs:subClassOf obo:BFO_0000030 ;
-	skos:editorialNote "BFO Alignment: Equipment is clearly a material entity. Initial mapping will map to the 'object' subclass."^^xsd:string ;
+	gist:bfoMappingNote "Equipment is clearly a material entity. Initial mapping will map to the object subclass."^^xsd:string ;
 	.
 
 gist:Event
@@ -79,7 +86,7 @@ gist:GeoRegion
 
 gist:GeoRoute
 	rdfs:subClassOf obo:BFO_0000006 ;
-	skos:editorialNote "BFO Alignment: Routes are collections of one dimensional regions, but they may trace out a 2D path."^^xsd:string ;
+	gist:bfoMappingNote "Routes are collections of one dimensional regions, but they may trace out a 2D path."^^xsd:string ;
 	.
 
 gist:GeoSegment
@@ -92,7 +99,7 @@ gist:GeoVolume
 
 gist:IntellectualProperty
 	rdfs:subClassOf obo:BFO_0000002 ;
-	skos:editorialNote "BFO Alignment: Intellectual property includes both immaterial knowledge and physically represented knowledge."^^xsd:string ;
+	gist:bfoMappingNote "Intellectual property includes both immaterial knowledge and physically represented knowledge."^^xsd:string ;
 	.
 
 gist:Intention
@@ -101,7 +108,7 @@ gist:Intention
 
 gist:Language
 	rdfs:subClassOf obo:BFO_0000031 ;
-	skos:editorialNote "BFO Alignment: Language fits the pattern of being continuant because it persists through change, but doesn't have an independent nature."^^xsd:string ;
+	gist:bfoMappingNote "Language fits the pattern of being continuant because it persists through change, but doesn't have an independent nature."^^xsd:string ;
 	.
 
 gist:Magnitude
@@ -114,12 +121,12 @@ gist:Network
 
 gist:NetworkLink
 	rdfs:subClassOf obo:BFO_0000024 ;
-	skos:editorialNote "BFO Alignment: Fiat object part is a pretty good cover for network link."^^xsd:string ;
+	gist:bfoMappingNote "Fiat object part is a pretty good cover for network link."^^xsd:string ;
 	.
 
 gist:NetworkNode
 	rdfs:subClassOf obo:BFO_0000024 ;
-	skos:editorialNote "BFO Alignment: Network node also fits the fiat object part as the node could be virtual or instantiated."^^xsd:string ;
+	gist:bfoMappingNote "Network node also fits the fiat object part as the node could be virtual or instantiated."^^xsd:string ;
 	.
 
 gist:Obligation
@@ -128,12 +135,12 @@ gist:Obligation
 
 gist:OrderedMember
 	rdfs:subClassOf obo:BFO_0000023 ;
-	skos:editorialNote "BFO Alignment: The ordered member defines the role the proxied real world item plays in the ordered collection."^^xsd:string ;
+	gist:bfoMappingNote "The ordered member defines the role the proxied real world item plays in the ordered collection."^^xsd:string ;
 	.
 
 gist:Organization
 	rdfs:subClassOf obo:BFO_0000141 ;
-	skos:editorialNote "BFO Alignment: Organization is clearly an independent continuant and immaterial. May need to update to be consistent with Common Core Ontology as well."^^xsd:string ;
+	gist:bfoMappingNote "Organization is clearly an independent continuant and immaterial. May need to update to be consistent with Common Core Ontology as well."^^xsd:string ;
 	.
 
 gist:PhysicalIdentifiableItem
@@ -143,7 +150,7 @@ gist:PhysicalIdentifiableItem
 
 gist:PhysicalSubstance
 	rdfs:subClassOf obo:BFO_0000040 ;
-	skos:editorialNote "BFO Alignment: Physical substance is a material entity, but not an object or aggregate as those are physical identifiable items and collections."^^xsd:string ;
+	gist:bfoMappingNote "Physical substance is a material entity, but not an object or aggregate as those are physical identifiable items and collections."^^xsd:string ;
 	.
 
 gist:SchemaMetaData
@@ -164,7 +171,7 @@ gist:Template
 
 gist:TemporalRelation
 	rdfs:subClassOf obo:BFO_0000145 ;
-	skos:editorialNote "BFO Alignment: Other potential matches include role and occurrent."^^xsd:string ;
+	gist:bfoMappingNote "Other potential matches include role and occurrent."^^xsd:string ;
 	.
 
 gist:TimeInterval
@@ -172,6 +179,5 @@ gist:TimeInterval
 	.
 
 gist:UnitOfMeasure
-	skos:editorialNote "BFO Alignment: Unclear if unit of measure fits in BFO. To avoid potentially inconsistent ontologies, it is initially not mapped to BFO."^^xsd:string ;
+	gist:bfoMappingNote "Unclear if unit of measure fits in BFO. To avoid potentially inconsistent ontologies, it is initially not mapped to BFO."^^xsd:string ;
 	.
-


### PR DESCRIPTION
Switch "BFO Annotation: " prefix on editorial note to a sub-property of editorial note based on [this conversation](https://teams.microsoft.com/l/message/19:2eb20a9c098c4e9897187b012b2bfc65@thread.skype/1727809969861?tenantId=10ab0a6b-ac6a-4089-b3a8-a4d283e2520d&groupId=b3c70198-eaa0-4d27-bc32-86f07358eae1&parentMessageId=1727809969861&teamName=Semantic%20Arts&channelName=team-ontologist&createdTime=1727809969861).

I decided to make the annotation property BFO specific because it is likely that people will import multiple bridges at once and need to know what note goes with a given mapping.
- People who use BFO as an upper ontology and CCO as a mid-level ontology will use both mappings
- We will import both mappings to ensure consistency among BFO, CCO, and both bridges.